### PR TITLE
Configuring typeORM and creating products migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "echo \"Error: no test specified\" &amp;&amp; exit 1",
     "dev": "ts-node-dev -r tsconfig-paths/register --inspect --transpile-only --ignore-watch node_modules src/shared/http/server.ts",
     "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint . --ext .ts --fix"
+    "lint-fix": "eslint . --ext .ts --fix",
+    "typeorm": "ts-node-dev ./node_modules/typeorm/cli.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/src/shared/typeorm/migrations/1673660408492-CreateProducts.ts
+++ b/src/shared/typeorm/migrations/1673660408492-CreateProducts.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateProducts1673660408492 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'products',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+          },
+          {
+            name: 'price',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+          },
+          {
+            name: 'quantity',
+            type: 'int',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('products');
+  }
+}


### PR DESCRIPTION
To execute:
```
            name: 'id',
            type: 'uuid',
            isPrimary: true,
            generationStrategy: 'uuid',
            default: 'uuid_generate_v4()',
```
an extension needs to be added on Postgres 

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/17836184/212723488-40b83d72-bdcd-4d2c-a261-4778ea124f02.png">

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/17836184/212723772-b6fabaad-04c3-4450-9a67-030552234e5a.png">


Commands:
```
yarn typeorm migration:create -n CreateProducts
 yarn typeorm migration:run
```
